### PR TITLE
patched $rm_unknown and $rm_storage_unknown sub

### DIFF
--- a/modules/host_runtime_info.pm
+++ b/modules/host_runtime_info.pm
@@ -236,13 +236,38 @@ sub host_runtime_info
        # Ignore unknown sensors
        # https://kb.vmware.com/s/article/57171
        my $rm_unknown = sub {
-          lc($_[0]->{status}->{key}) ne "unknown"
+          if (defined($_[0]->{status}))
+          {
+              $key = lc($_[0]->{status}->{key});
+              if ($key ne "unknown")
+              {
+                  return($key);
+              };
+          };
+          
+          if (defined($_[0]->{healthState}))
+          {
+              $key = lc($_[0]->{healthState}->{key});
+              if ($key ne "unknown")
+              {
+                  return($key);
+              };
+          };
+          
+          return();
        };
 
        # Some systems reports a broken "Memory" device at the storage tree
        # unsure how to deal with that
        my $rm_storage_unknown = sub {
-          lc($_[0]->{status}->{key}) ne "unknown" && lc($_[0]->{name}) ne "memory"
+          $name = $_[0]->{name};
+          $key = lc($_[0]->{status}->{key});
+          if ((not $name =~ /.+?Unconfigured Disk.*/) && ($key ne "unknown") && ($name ne "memory"))
+          {
+              return($key);
+          };
+          
+          return();
        };
 
        if (defined($runtime->healthSystemRuntime))


### PR DESCRIPTION
Patch for $rm_unknown and $rm_storage_unknown sub.

For $rm_unknown patch:
I was getting uninitialized value errors with ESXi 7.x on HPE ProLiant servers. So I did my best to figure out what was causing this problem. It turned out that the hash keys for different sensors have different state names.
So I added a check to determine which key is present. Then the status is checked. If the status is unknown, nothing is returned. Otherwise, the status is reported.

For $rm_storage_unknown patch:
It is a workaround to exclude some false positives from the result. The bug is related to ESXi 7.x and HPE ProLiant 10th generation servers that have an up-to-date SPP installed. The problem is a bug in the HPE RAID driver.
The ESXi reports random unconfigured disks. So I excluded them from the report.